### PR TITLE
Try to enable h264 decoding / encoding using NVIDIA GPU

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
     "aioice>=0.9.0,<1.0.0",
-    "av>=9.0.0,<12.0.0",
+    "av>=9.0.0,<12.2.0",
     "cffi>=1.0.0",
     "cryptography>=42.0.0",
     'dataclasses; python_version < "3.7"',

--- a/src/aiortc/codecs/__init__.py
+++ b/src/aiortc/codecs/__init__.py
@@ -1,3 +1,5 @@
+import os
+
 from typing import Dict, List, Optional, Union
 
 from ..rtcrtpparameters import (
@@ -14,6 +16,8 @@ from .g711 import PcmaDecoder, PcmaEncoder, PcmuDecoder, PcmuEncoder
 from .h264 import H264Decoder, H264Encoder, h264_depayload
 from .opus import OpusDecoder, OpusEncoder
 from .vpx import Vp8Decoder, Vp8Encoder, vp8_depayload
+
+ENABLE_CUDA_H264 = os.getenv('ENABLE_AIORTC_CUDA_H264') == '1'
 
 PCMU_CODEC = RTCRtpCodecParameters(
     mimeType="audio/PCMU", clockRate=8000, channels=1, payloadType=0
@@ -148,7 +152,11 @@ def get_decoder(codec: RTCRtpCodecParameters) -> Decoder:
     elif mimeType == "audio/pcmu":
         return PcmuDecoder()
     elif mimeType == "video/h264":
-        return H264Decoder()
+        if ENABLE_CUDA_H264:
+            from .cuda_h264 import CudaH264Decoder
+            return CudaH264Decoder()
+        else:
+            return H264Decoder()
     elif mimeType == "video/vp8":
         return Vp8Decoder()
     else:

--- a/src/aiortc/codecs/cuda_h264.py
+++ b/src/aiortc/codecs/cuda_h264.py
@@ -1,0 +1,80 @@
+import logging
+from typing import List
+
+import ctypes
+import PyNvVideoCodec as nvc
+import nvcv
+from av import VideoFrame
+from av.frame import Frame
+
+from ..jitterbuffer import JitterFrame
+from ..mediastreams import VIDEO_TIME_BASE
+from .base import Decoder
+
+logger = logging.getLogger(__name__)
+
+class CudaFrame(VideoFrame):
+    """
+    Stores a decoded frame from the CUDA decoder.
+
+    It's expected that the decoded frame (which can be accessed either via to_nvcv_tensor,
+    or decoded_frame) will undergo further processing on the GPU,
+    before being reconstituted into another av.Frame that can be fed to an encoder.
+    """
+
+    def __new__(cls, decoded_frame: nvc.DecodedFrame = None, decoded_frame_width: int = 0, decoded_frame_height: int = 0):
+        return super().__new__(cls, width=0, height=0, format="yuv420p")
+
+    def __init__(self, decoded_frame: nvc.DecodedFrame = None, decoded_frame_width: int = 0, decoded_frame_height: int = 0):
+        # create VideoFrame with zero width and height to prevent allocation
+        # of underlying plane buffers
+        self.decoded_frame_width = decoded_frame_width
+        self.decoded_frame_height = decoded_frame_height
+        self.decoded_frame = decoded_frame
+
+    @property
+    def width(self):
+        """Width of the image, in pixels."""
+        return self.decoded_frame_width
+
+    @property
+    def height(self):
+        """Height of the image, in pixels."""
+        return self.decoded_frame_height
+
+    def to_nvcv_tensor(self):
+        return nvcv.as_tensor(nvcv.as_image(self.decoded_frame.nvcv_image(), nvcv.Format.U8))
+
+
+class CudaH264Decoder(Decoder):
+    def __init__(self) -> None:
+        self.nv_dec = nvc.CreateDecoder(codec=nvc.cudaVideoCodec.H264, usedevicememory=True, enableasyncallocations=False)
+        self.packet = nvc.PacketData()
+        self.packet_c_bytes = None
+
+    def decode(self, encoded_frame: JitterFrame) -> List[Frame]:
+        frames = []
+        
+        if (self.packet_c_bytes is None) or (len(encoded_frame.data) > len(self.packet_c_bytes)):
+            self.packet_c_bytes = (ctypes.c_byte * len(encoded_frame.data)).from_buffer_copy(encoded_frame.data)
+        else:
+            ctypes.memmove(ctypes.addressof(self.packet_c_bytes), encoded_frame.data, len(encoded_frame.data))
+        
+        self.packet.bsl_data = ctypes.cast(self.packet_c_bytes, ctypes.c_void_p).value
+        self.packet.bsl = len(encoded_frame.data)
+
+        for decoded_frame in self.nv_dec.Decode(self.packet):
+            # NOTE: there's no real reason we couldn't support other formats here,
+            # main issue is finding a suitable VideoFrame format to match
+            assert decoded_frame.format == nvc.Pixel_Format.NV12, "unsupported pixel format"
+            frame = CudaFrame(
+                decoded_frame,
+                decoded_frame_width=self.nv_dec.GetWidth(),
+                decoded_frame_height=self.nv_dec.GetHeight()
+            )
+            # decoded_frame.timestamp always seems to be zero, so use encoded_frame.timestamp instead 
+            frame.pts = encoded_frame.timestamp
+            frame.time_base = VIDEO_TIME_BASE
+            frames.append(frame)
+
+        return frames

--- a/src/aiortc/codecs/h264.py
+++ b/src/aiortc/codecs/h264.py
@@ -322,6 +322,7 @@ class H264Encoder(Encoder):
                         frame.height,
                         bitrate=self.target_bitrate,
                     )
+            logger.info("Encoding with " + self.codec.name)
 
         data_to_send = b""
         for package in self.codec.encode(frame):

--- a/src/aiortc/codecs/h264.py
+++ b/src/aiortc/codecs/h264.py
@@ -104,7 +104,10 @@ class H264PayloadDescriptor:
 
 class H264Decoder(Decoder):
     def __init__(self) -> None:
-        self.codec = av.CodecContext.create("h264", "r")
+        hwaccel = {'device_type_name': 'cuda'}
+        self.codec = av.CodecContext.create("h264", "r", hwaccel=dict(hwaccel))
+        #self.codec = av.CodecContext.create("h264", "r")
+        logger.info("CUDA h264 decoder enabled? " + str(self.codec.using_hwaccel))
 
     def decode(self, encoded_frame: JitterFrame) -> List[Frame]:
         try:
@@ -124,7 +127,10 @@ class H264Decoder(Decoder):
 def create_encoder_context(
     codec_name: str, width: int, height: int, bitrate: int
 ) -> Tuple[av.CodecContext, bool]:
-    codec = av.CodecContext.create(codec_name, "w")
+    hwaccel = {'device_type_name': 'cuda'}
+    codec = av.CodecContext.create(codec_name, "w", hwaccel=dict(hwaccel))
+    #codec = av.CodecContext.create(codec_name, "w")
+    logger.info("CUDA h264 encoder enabled? "  + str(codec.using_hwaccel))
     codec.width = width
     codec.height = height
     codec.bit_rate = bitrate

--- a/src/aiortc/codecs/h264.py
+++ b/src/aiortc/codecs/h264.py
@@ -5,8 +5,6 @@ from itertools import tee
 from struct import pack, unpack_from
 from typing import Iterator, List, Optional, Sequence, Tuple, Type, TypeVar
 
-import PyNvVideoCodec as nvc
-
 import av
 from av.frame import Frame
 from av.packet import Packet
@@ -14,11 +12,6 @@ from av.packet import Packet
 from ..jitterbuffer import JitterFrame
 from ..mediastreams import VIDEO_TIME_BASE, convert_timebase
 from .base import Decoder, Encoder
-
-import ctypes
-import nvcv
-import cvcuda
-import torch
 
 logger = logging.getLogger(__name__)
 
@@ -111,63 +104,22 @@ class H264PayloadDescriptor:
 
 class H264Decoder(Decoder):
     def __init__(self) -> None:
-        self.nv_dec = nvc.CreateDecoder(codec=nvc.cudaVideoCodec.H264, usedevicememory=True, enableasyncallocations=False)
-        self.cvcuda_rgb24_tensor = None
-        self.torch_rgb24_tensor = None
-        self.packet = nvc.PacketData()
-        self.packet_c_bytes = None
+        self.codec = av.CodecContext.create("h264", "r")
 
     def decode(self, encoded_frame: JitterFrame) -> List[Frame]:
-        frames = []
         try:
-            if (self.packet_c_bytes is None) or (len(encoded_frame.data) > len(self.packet_c_bytes)):
-                self.packet_c_bytes = (ctypes.c_byte * len(encoded_frame.data)).from_buffer_copy(encoded_frame.data)
-            else:
-                ctypes.memmove(ctypes.addressof(self.packet_c_bytes), encoded_frame.data, len(encoded_frame.data))
-            
-            self.packet.bsl_data = ctypes.cast(self.packet_c_bytes, ctypes.c_void_p).value
-            self.packet.bsl = len(encoded_frame.data)
-
-            for decoded_frame in self.nv_dec.Decode(self.packet):
-                cvcuda_yuv_tensor = nvcv.as_tensor(
-                    nvcv.as_image(decoded_frame.nvcv_image(), nvcv.Format.U8)
-                )
-                if cvcuda_yuv_tensor.layout == "NCHW":
-                    cvcuda_yuv_tensor = cvcuda.reformat(cvcuda_yuv_tensor, "NHWC")
-                
-                # TODO: should reallocate this tensor if the width/height changes
-                if self.cvcuda_rgb24_tensor is None:
-                    width = self.nv_dec.GetWidth()
-                    height = self.nv_dec.GetHeight()
-                    print("nv_dec width", width)
-                    print("nv_dec height", height)
-                    self.cvcuda_rgb24_tensor = cvcuda.Tensor(
-                        (1, height, width, 3),
-                        nvcv.Type.U8,
-                        nvcv.TensorLayout.NHWC,
-                    )
-                
-                # convert YUV->RGB on GPU
-                # NOTE: probably don't really need to do this conversion,
-                # but av.VideoFrame.from_ndarray expects an nv12 tensor to have a different
-                # shape than cvcuda_yuv_tensor has, and nv12 is a bit of an odd duck anyway,
-                # so it's just easier to create an rgb24 tensor!
-                cvcuda.cvtcolor_into(self.cvcuda_rgb24_tensor, cvcuda_yuv_tensor, cvcuda.ColorConversion.YUV2RGB_NV12)
-                # copy to CPU and convert NHWC -> HWC
-                if self.torch_rgb24_tensor is None:
-                    self.torch_rgb24_tensor = torch.as_tensor(self.cvcuda_rgb24_tensor.cuda()).squeeze(0).cpu()
-                else:
-                    self.torch_rgb24_tensor.copy_(torch.as_tensor(self.cvcuda_rgb24_tensor.cuda()).squeeze(0))
-                frame = av.VideoFrame.from_ndarray(self.torch_rgb24_tensor.numpy(), "rgb24")
-                frame.pts = encoded_frame.timestamp
-                frame.time_base = VIDEO_TIME_BASE
-                frames.append(frame)
-        except Exception as e:
+            packet = av.Packet(encoded_frame.data)
+            packet.pts = encoded_frame.timestamp
+            packet.time_base = VIDEO_TIME_BASE
+            frames = self.codec.decode(packet)
+        except av.AVError as e:
             logger.warning(
                 "H264Decoder() failed to decode, skipping package: " + str(e)
             )
+            return []
 
         return frames
+
 
 def create_encoder_context(
     codec_name: str, width: int, height: int, bitrate: int


### PR DESCRIPTION
This requires a custom build of PyAV from this branch https://github.com/LobsterUberlord/PyAV/pull/1

To get this running:
1. In the PyAV repo, check out the relevant branch then build a wheel:
   ```bash
   source scripts/activate.sh
   ./scripts/build-deps
   make
   python3 setup.py bdist_wheel
   ```
2. In the `aiortc` repo, install the PyAV wheel:
    ```bash
    python3 -m venv venv
    source venv/bin/activate
    pip3 install --force-reinstall <path/to/pyav.wheel>
    pip3 install .
    ```
3. Run `examples/server`:
    ```bash
    cd examples/server
    python3 server.py --port 8085
    ```
4. Open the WebRTC demo page, tick Video, select a transform (or none) and select H264, then start the stream.

**NOTE**
`PyNvVideoCodec` changes require installation of [deepstream libs](https://github.com/NVIDIA-AI-IOT/deepstream_libraries/tree/main#deepstream-libraries-installation), and PyTorch (`pip3 install torch`) which is used in  `examples/server`.